### PR TITLE
fix: handle nil DirEntry in WalkDir to prevent panic

### DIFF
--- a/sdc_executor/validators/sdc_validator/README.md
+++ b/sdc_executor/validators/sdc_validator/README.md
@@ -13,10 +13,22 @@ cd ocp-diag-core
 
 ## Building the SDC Validator
 
+### Online Build (standard)
+
 ```bash
 cd sdc_executor/validators/sdc_validator
 go mod tidy
 go build -o sdc_validator
+```
+
+### Offline Build (for corporate environments)
+
+For environments that block proxy.golang.org, use the vendor directory:
+
+```bash
+cd sdc_executor/validators/sdc_validator
+./create_vendor.sh  # Creates vendor directory with dependencies
+go build -mod=vendor -o sdc_validator
 ```
 
 ## Running the SDC Validator
@@ -114,6 +126,10 @@ go test ./pkg/schema_validator/
 
 **7. `footprint_tax_percent value must be >= 0.0`**
 - **Solution:** Verify footprint_tax_percent values are non-negative or null
+
+**8. `panic: runtime error: invalid memory address or nil pointer dereference`**
+- **Issue:** WalkDir encounters filesystem access errors and passes nil DirEntry
+- **Solution:** This has been fixed in the latest version - update to the latest code
 
 ### Validation Details
 

--- a/sdc_executor/validators/sdc_validator/pkg/schema_validator/validator.go
+++ b/sdc_executor/validators/sdc_validator/pkg/schema_validator/validator.go
@@ -44,6 +44,13 @@ func New(schemaPath string) (*SchemaValidator, error) {
 
 	// Load OCP standard schemas
 	err := filepath.WalkDir(path.Dir(schemaPath), func(fpath string, d fs.DirEntry, err error) error {
+		// SDC fix: Handle WalkDir errors and nil DirEntry to prevent panic
+		if err != nil {
+			return err
+		}
+		if d == nil {
+			return nil
+		}
 		if !d.IsDir() && filepath.Ext(fpath) == ".json" {
 			url, err := getSchemaURL(fpath)
 			if err != nil {
@@ -74,6 +81,13 @@ func New(schemaPath string) (*SchemaValidator, error) {
 	sdcSchemaDir := "../../schema/output"
 	if _, err := os.Stat(sdcSchemaDir); err == nil {
 		err := filepath.WalkDir(sdcSchemaDir, func(fpath string, d fs.DirEntry, err error) error {
+			// SDC fix: Handle WalkDir errors and nil DirEntry to prevent panic
+			if err != nil {
+				return err
+			}
+			if d == nil {
+				return nil
+			}
 			if !d.IsDir() && filepath.Ext(fpath) == ".json" {
 				url, err := getSchemaURL(fpath)
 				if err != nil {


### PR DESCRIPTION
Fix nil pointer dereference panic in SDC validator when WalkDir encounters filesystem access errors.

## Changes
- Add proper error and nil checks in WalkDir callbacks
- Fix panic when accessing directories with permission issues
- Update README with troubleshooting section for this issue
- Add offline build instructions for corporate environments

## Root Cause
The `filepath.WalkDir` function can pass nil DirEntry when encountering filesystem access errors, causing panic when `d.IsDir()` is called without nil check.

## Testing
Validator now handles filesystem errors gracefully and should work with the original command:
```bash
./sdc_validator -schema ../../../../json_spec/output/root.json ../../schema/examples/sdc_output_example.jsonl
```

Generated with [Claude Code](https://claude.ai/code)